### PR TITLE
Connection Logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "rok"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "bincode",
  "bytes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 bincode = "1.3.3"
 serde = { version = "1.0.137", features = ["derive"] }
+ansi_term = "0.12.1"
 
 [[bin]]
 name = "server"

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,14 +95,12 @@ async fn run_data_channel(domain: String) -> std::io::Result<()> {
                 state: state.clone(),
             };
 
-            tokio::io::copy_bidirectional(&mut logger_src, &mut logger_dst).await;
-            // starting from here
+            let _ = tokio::io::copy_bidirectional(&mut logger_src, &mut logger_dst).await;
         }
     }
 }
 
 struct LoggerState {
-    counter: usize,
     timestamp: Option<Instant>,
 }
 
@@ -114,10 +112,7 @@ struct Logger<T: AsyncRead + AsyncWrite> {
 
 impl LoggerState {
     fn new() -> Self {
-        Self {
-            counter: 0,
-            timestamp: None,
-        }
+        Self { timestamp: None }
     }
 }
 
@@ -140,7 +135,7 @@ impl<T: AsyncRead + AsyncWrite> AsyncRead for Logger<T> {
 
                         let mut state = self.state.lock().unwrap();
                         if let Some(instant) = state.timestamp.take() {
-                            let (status_code, status) = log.split_once(' ').unwrap();
+                            let (status_code, _status) = log.split_once(' ').unwrap();
 
                             let status_code: u32 = status_code.parse().unwrap();
                             let color_status = match status_code {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use ansi_term::Colour;
 use bytes::Buf;
 use std::error::Error;
-use std::io::{self};
+use std::io;
 use std::pin::Pin;
 use std::str;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
This PR is the result of pairing with @erwanor during our time in [the Recurse Center](https://www.recurse.com/). The PR is mainly about:

- Logging each HTTP request/response we receive/respond into the client terminal. 
- On top of that, we also include the duration taken for the local server response to the client.
- Lastly, it's beautify by adding alignments and colors to the log out puts.

## Implementation Details

### Support logging

Initially, we are forwarding the bytes from one `TcpStream` to another `TcpStream` using `copy_bidirectional`. However, since it encapsulates the bytes copied, there's no way we could peek into the bytes we receive. Initially, we thought of two possible ways to implement the logging:

- Write our own copy bidirectional manually. Basically, read on `TcpStream` and the write it to another manually.
- Extend copy_bidirectional to accept an event channel. This mean that we can just pass in a `Sender` to the `copy_bidirectional` function, which will call `send` on every read it received. Then, our code can listen to the `Receiver` and process the bytes as needed.
  - This approach also means that we need to copy most of the code from the existing `copy_bidirectional` implementation.

On the next day of Pairing, Erwan thought of another approach: we can implement our own `AsyncRead` and `AsyncWrite` trait to wrap the `TcpStream` and pass it to `copy_bidrectional`. This way, we could also peek into the bytes when `poll_read` is called by `copy_bidirectional`. We decided to approach with this approach and it works really well. This result in the `Logger` struct that implement `AsyncRead + AsyncWrite`, where the `inner` is a `TcpStream` in our case.

### Tracking state

The next feature we want to support is to track the duration takes. This mean that we need to have an `Instant::now()` created when a request is received and called `elapsed()` when a response is received. We tried a couple of different ways and ended up adding a `LoggerState` struct that will hold the shared state by both `Logger`. The state is then wrapped in `Arc<Mutex>` to allow it to be hold by multiple struct. 

It works as we tested, but we also learn that in browser, a TCP connection might be reused across refresh and and tabs. So, we can't just assume that our `TcpStream` will be closed once a request is served. Hence, we need to reset the `timestamp` state everytime a response is logged. This is achieved by calling `timestamp.take()` to take out the `Instant` in our `Option` and replace it with `None`.
